### PR TITLE
Fix: Add immediate image preview to EditPizzaForm

### DIFF
--- a/src/components/admin/PizzaManager.tsx
+++ b/src/components/admin/PizzaManager.tsx
@@ -383,6 +383,13 @@ const EditPizzaForm = ({
           className="bg-gray-700 border-gray-600 text-white text-sm"
           placeholder="URL da imagem"
         />
+        {formData.imagem_url && (
+          <img
+            src={formData.imagem_url}
+            alt="Preview da Pizza"
+            className="mt-2 w-32 h-32 object-cover rounded border border-gray-600"
+          />
+        )}
       </div>
       <div className="flex items-center space-x-2">
         <input


### PR DESCRIPTION
This commit enhances the pizza editing experience by adding an immediate image preview to the `EditPizzaForm` in `PizzaManager.tsx`.

- An `<img>` tag has been added to the form, bound to the `imagem_url` state.
- The preview updates instantly when a new image is successfully uploaded or when the image URL is manually modified in the input field.

This addresses your feedback to make the image update visible within the form before saving the changes.